### PR TITLE
sqlite3 gem only in dev/test for heroku.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ ruby '2.2.5'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.7.1'
-# Use sqlite3 as the database for Active Record, heroku doesn't support sqlite3
-gem 'sqlite3'
 # Use postgres instead as the database
 gem 'pg'
 # Use SCSS for stylesheets
@@ -40,6 +38,8 @@ gem 'fullcalendar_engine', "1.0.4"
 group :development, :test do
   gem 'jasmine-rails' # if you plan to use JavaScript/CoffeeScript
   gem 'byebug'
+  # Use sqlite3 as the database for Active Record, heroku doesn't support sqlite3
+  gem 'sqlite3'
 end
 # setup Cucumber, RSpec, Guard support
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     byebug (9.0.6)
     cane (2.6.2)
       parallel
-    capybara (2.9.2)
+    capybara (2.10.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -217,9 +217,8 @@ GEM
     multipart-post (2.0.0)
     nenv (0.3.0)
     netrc (0.11.0)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -243,7 +242,6 @@ GEM
     path_expander (1.0.0)
     pg (0.19.0)
     phantomjs (2.1.1.0)
-    pkg-config (1.1.7)
     procto (0.0.3)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -325,8 +323,8 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     ruby-progressbar (1.8.1)
-    ruby_dep (1.4.0)
-    ruby_parser (3.8.2)
+    ruby_dep (1.5.0)
+    ruby_parser (3.8.3)
       sexp_processor (~> 4.1)
     sass (3.4.22)
     sass-rails (5.0.6)
@@ -335,7 +333,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sdoc (0.4.1)
+    sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     sexp_processor (4.7.0)
@@ -355,7 +353,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.11)
+    sqlite3 (1.3.12)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -420,4 +418,4 @@ RUBY VERSION
    ruby 2.2.5p319
 
 BUNDLED WITH
-   1.13.2
+   1.13.5


### PR DESCRIPTION
moved gem 'sqlite3' to only development and test environments. heroku doesn't like sqlite3
